### PR TITLE
Feature: Persist Default Bump Phrase

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit_message: Bump version to {{version}}
-          minor: Feature, Feat, feat
-          patch: Patch, Fix
+          minor: Feature:, Feature/, feature:, feature/
+          patch: Patch:, Patch/, Fix:, Fix/
           # bump: ${{ contains(github.ref, 'releases/') && $(echo '${{ github.ref }}' | awk -F '/' '{print $NF}' ) }}
 
       - name:  'Output Step'

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Use the following inputs with the `steps.with` key
 | `patch`           | `''`                              | String  | (Optional) Phrases to test head commit against. Your inputs extend default phrases.                 |
 | `ref`             | `${{ github.ref }}`               | String  | (Optional) The target branch to push the version bump commit to.                                    |
 | `bump`            | `false`                           | String  | (Optional) Pass user defined version. Must be a valid semver string. Ex. 0.1.0. The "v" is optional |
+| `persist_phrase`  | `false`                           | Boolean | (Optional) Persist default phrases with custom phrases.                                             |
 
 ### outputs
 

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: (Optional) The target branch to push the version bump commit to.
     default: ${{ github.ref }}
     required: false
+  persist_phrase:
+    description: (Optional) Persist default phrases with custom phrases.
+    default: 'false'
+    required: false
 outputs:
   version:
     description: 'Version Bump'

--- a/src/context.ts
+++ b/src/context.ts
@@ -25,6 +25,10 @@ const coreInput = (input: string, required: boolean = false) => {
   return core.getInput(input, { required });
 };
 
+const persist = (per: boolean, def: string[]) => {
+  return (per && def) || [];
+};
+
 export const getInputs = async (): Promise<Inputs> => {
   const defaults = {
     major: ['BREAKING CHANGE', 'major'],
@@ -37,21 +41,22 @@ export const getInputs = async (): Promise<Inputs> => {
   const commitMessage = coreInput('commit_message');
   const pathToPackage = coreInput('path_to_package');
   const tag = /true/i.test(coreInput('tag'));
+  const per = /true/i.test(coreInput('persist_phrase'));
 
   // Dependant Inputs
   const bumpInput = coreInput('bump');
   const bump = /false/i.test(boolConvert(bumpInput)) ? false : bumpInput;
 
   const majorInput = coreInput('major');
-  const major = (majorInput.length && [...defaults.major, ...majorInput.split(',')]) || defaults.major;
+  const major = [...persist(per, defaults.major), ...majorInput.split(',')];
 
   const minorInput = coreInput('minor');
-  const minor = (minorInput.length && [...defaults.minor, ...minorInput.split(',')]) || defaults.minor;
+  const minor = [...persist(per, defaults.minor), ...minorInput.split(',')];
 
   const patchInput = coreInput('patch');
-  const patch = (patchInput.length && [...defaults.patch, ...patchInput.split(',')]) || undefined;
+  const patch = [...persist(per, defaults.patch), ...patchInput.split(',')];
 
-  const ref = coreInput('ref').split('/').pop();
+  const ref = coreInput('ref').split('/').pop()!;
 
   return {
     token,

--- a/src/context.ts
+++ b/src/context.ts
@@ -44,18 +44,10 @@ export const getInputs = async (): Promise<Inputs> => {
   const per = /true/i.test(coreInput('persist_phrase'));
 
   // Dependant Inputs
-  const bumpInput = coreInput('bump');
-  const bump = /false/i.test(boolConvert(bumpInput)) ? false : bumpInput;
-
-  const majorInput = coreInput('major');
-  const major = [...persist(per, defaults.major), ...majorInput.split(',')];
-
-  const minorInput = coreInput('minor');
-  const minor = [...persist(per, defaults.minor), ...minorInput.split(',')];
-
-  const patchInput = coreInput('patch');
-  const patch = [...persist(per, defaults.patch), ...patchInput.split(',')];
-
+  const bump = /false/i.test(boolConvert(coreInput('bump'))) ? false : coreInput('bump');
+  const major = [...persist(per, defaults.major), ...coreInput('major').split(',')];
+  const minor = [...persist(per, defaults.minor), ...coreInput('minor').split(',')];
+  const patch = [...persist(per, defaults.patch), ...coreInput('patch').split(',')];
   const ref = coreInput('ref').split('/').pop()!;
 
   return {

--- a/src/context.ts
+++ b/src/context.ts
@@ -35,16 +35,26 @@ export const getInputs = async (): Promise<Inputs> => {
     ref: 'main',
   };
 
+  const token = coreInput('token', true);
+  const commitMessage = coreInput('commit_message') || defaults.commitMessage;
+  const pathToPackage = coreInput('path_to_package') || defaults.pathToPackage;
+  const major = (coreInput('major').length && [...defaults.major, ...coreInput('major').split(',')]) || defaults.major;
+  const minor = (coreInput('minor').length && [...defaults.minor, ...coreInput('minor').split(',')]) || defaults.minor;
+  const patch = (coreInput('patch').length && [...defaults.patch, ...coreInput('patch').split(',')]) || undefined;
+  const tag = /true/i.test(coreInput('tag'));
+  const ref = coreInput('ref').split('/').pop() || defaults.ref;
+  const bump = /false/i.test(boolConvert(coreInput('bump'))) ? false : coreInput('bump');
+
   return {
-    token: coreInput('token', true),
-    commitMessage: coreInput('commit_message') || defaults.commitMessage,
-    pathToPackage: coreInput('path_to_package') || defaults.pathToPackage,
-    major: (coreInput('major').length && [...defaults.major, ...coreInput('major').split(',')]) || defaults.major,
-    minor: (coreInput('minor').length && [...defaults.minor, ...coreInput('minor').split(',')]) || defaults.minor,
-    patch: (coreInput('patch').length && [...defaults.patch, ...coreInput('patch').split(',')]) || undefined,
-    tag: /true/i.test(coreInput('tag')),
-    ref: coreInput('ref').split('/').pop() || defaults.ref,
-    bump: /false/i.test(boolConvert(coreInput('bump'))) ? false : coreInput('bump'),
+    token,
+    commitMessage,
+    pathToPackage,
+    major,
+    minor,
+    patch,
+    tag,
+    ref,
+    bump,
   };
 };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -32,7 +32,13 @@ export const getInputs = async (): Promise<Inputs> => {
     patch: [''],
   };
 
-  // Mutated Inputs
+  // Independant Inputs
+  const token = coreInput('token', true);
+  const commitMessage = coreInput('commit_message');
+  const pathToPackage = coreInput('path_to_package');
+  const tag = /true/i.test(coreInput('tag'));
+
+  // Dependant Inputs
   const bumpInput = coreInput('bump');
   const bump = /false/i.test(boolConvert(bumpInput)) ? false : bumpInput;
 
@@ -46,12 +52,6 @@ export const getInputs = async (): Promise<Inputs> => {
   const patch = (patchInput.length && [...defaults.patch, ...patchInput.split(',')]) || undefined;
 
   const ref = coreInput('ref').split('/').pop();
-
-  // Non Mutated Inputs
-  const token = coreInput('token', true);
-  const commitMessage = coreInput('commit_message');
-  const pathToPackage = coreInput('path_to_package');
-  const tag = /true/i.test(coreInput('tag'));
 
   return {
     token,

--- a/src/context.ts
+++ b/src/context.ts
@@ -21,6 +21,10 @@ const boolConvert = (value: string) => {
   }
 };
 
+const coreInput = (input: string, required: boolean = false) => {
+  return core.getInput(input, { required });
+};
+
 export const getInputs = async (): Promise<Inputs> => {
   const defaults = {
     commitMessage: 'CI: Bump version to {{version}}',
@@ -32,15 +36,15 @@ export const getInputs = async (): Promise<Inputs> => {
   };
 
   return {
-    token: core.getInput('token', { required: true }),
-    commitMessage: core.getInput('commit_message') || defaults.commitMessage,
-    pathToPackage: core.getInput('path_to_package') || defaults.pathToPackage,
-    major: (core.getInput('major').length && [...defaults.major, ...core.getInput('major').split(',')]) || defaults.major,
-    minor: (core.getInput('minor').length && [...defaults.minor, ...core.getInput('minor').split(',')]) || defaults.minor,
-    patch: (core.getInput('patch').length && [...defaults.patch, ...core.getInput('patch').split(',')]) || undefined,
-    tag: /true/i.test(core.getInput('tag')),
-    ref: core.getInput('ref').split('/').pop() || defaults.ref,
-    bump: /false/i.test(boolConvert(core.getInput('bump'))) ? false : core.getInput('bump'),
+    token: coreInput('token', true),
+    commitMessage: coreInput('commit_message') || defaults.commitMessage,
+    pathToPackage: coreInput('path_to_package') || defaults.pathToPackage,
+    major: (coreInput('major').length && [...defaults.major, ...coreInput('major').split(',')]) || defaults.major,
+    minor: (coreInput('minor').length && [...defaults.minor, ...coreInput('minor').split(',')]) || defaults.minor,
+    patch: (coreInput('patch').length && [...defaults.patch, ...coreInput('patch').split(',')]) || undefined,
+    tag: /true/i.test(coreInput('tag')),
+    ref: coreInput('ref').split('/').pop() || defaults.ref,
+    bump: /false/i.test(boolConvert(coreInput('bump'))) ? false : coreInput('bump'),
   };
 };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -25,7 +25,7 @@ const coreInput = (input: string, required: boolean = false) => {
   return core.getInput(input, { required });
 };
 
-const persist = (per: boolean, def: string[]) => {
+const persist = (per: boolean = false, def: string[]) => {
   return (per && def) || [];
 };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -27,23 +27,31 @@ const coreInput = (input: string, required: boolean = false) => {
 
 export const getInputs = async (): Promise<Inputs> => {
   const defaults = {
-    commitMessage: 'CI: Bump version to {{version}}',
-    pathToPackage: process.env.GITHUB_WORKSPACE!,
     major: ['BREAKING CHANGE', 'major'],
     minor: ['feature', 'minor'],
     patch: [''],
-    ref: 'main',
   };
 
+  // Mutated Inputs
+  const bumpInput = coreInput('bump');
+  const bump = /false/i.test(boolConvert(bumpInput)) ? false : bumpInput;
+
+  const majorInput = coreInput('major');
+  const major = (majorInput.length && [...defaults.major, ...majorInput.split(',')]) || defaults.major;
+
+  const minorInput = coreInput('minor');
+  const minor = (minorInput.length && [...defaults.minor, ...minorInput.split(',')]) || defaults.minor;
+
+  const patchInput = coreInput('patch');
+  const patch = (patchInput.length && [...defaults.patch, ...patchInput.split(',')]) || undefined;
+
+  const ref = coreInput('ref').split('/').pop();
+
+  // Non Mutated Inputs
   const token = coreInput('token', true);
-  const commitMessage = coreInput('commit_message') || defaults.commitMessage;
-  const pathToPackage = coreInput('path_to_package') || defaults.pathToPackage;
-  const major = (coreInput('major').length && [...defaults.major, ...coreInput('major').split(',')]) || defaults.major;
-  const minor = (coreInput('minor').length && [...defaults.minor, ...coreInput('minor').split(',')]) || defaults.minor;
-  const patch = (coreInput('patch').length && [...defaults.patch, ...coreInput('patch').split(',')]) || undefined;
+  const commitMessage = coreInput('commit_message');
+  const pathToPackage = coreInput('path_to_package');
   const tag = /true/i.test(coreInput('tag'));
-  const ref = coreInput('ref').split('/').pop() || defaults.ref;
-  const bump = /false/i.test(boolConvert(coreInput('bump'))) ? false : coreInput('bump');
 
   return {
     token,


### PR DESCRIPTION
Simply, persist all the default phrases if input `persist_phrases` is set to `true`. Otherwise, custom phrases will replace the default phrases. This only applies to bump phrases which have custom phrases. If one bump phrase does not have custom phrases, the default is applied.
___
Ex.
```yaml
      - name: "Bump Version"
        uses: WormJim/version-bump-action@main
        with:
          minor: Feature:, Feature/, feature:, feature/
```

The example above will not extend the default phrases for minor.
Yet, the example below will

```yaml
      - name: "Bump Version"
        uses: WormJim/version-bump-action@main
        with:
          minor: Feature:, Feature/, feature:, feature/
          persist_phrases: true
```

A commit message with matching minor default phrases will be caught and a bump will be set.